### PR TITLE
fix: disable text select

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -8,6 +8,13 @@
    */
   position: fixed;
   width: 100%;
+  
+  /**
+   * Disables text selection
+   * for a more app-like experience.
+   */
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 body {


### PR DESCRIPTION
This PR disables text select so you can't accidentally highlight parts of the application. Text inputs remain editable, and the copy button still works. 