### PR TITLE
test: run in docker container

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.39.0-jammy
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,7 +30,8 @@ jobs:
         run: pnpm run build
         shell: sh
       - name: Run Tests
-        run: pnpm run test
+        # https://github.com/microsoft/playwright/issues/6500
+        run: HOME=/root pnpm run test
         shell: sh
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           version: 8
       - name: Install Dependencies
-        run: pnpm install && pnpm playwright install --with-deps
+        run: pnpm install
         shell: sh
       - name: Build Application
         run: pnpm run build


### PR DESCRIPTION
To prepare for adding screenshot tests, this PR gets tests running in a Docker container. This will let me use the same container locally to generate consistent screenshots.