### PR TITLE
fix: app correctly resizes on first load

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,12 +15,26 @@
   <body>
     <div id="app"></div>
     <script>
-      document.addEventListener("DOMContentLoaded", event => {
-        isBrowser = matchMedia("(display-mode: browser)").matches;
-        if (!isBrowser) {
+      /**
+       * In some browsers display-mode: standalone
+       * does not match on DOMContentLoaded.
+       * If it does, then we can resize the window
+       * right away. Otherwise, we need to wait for
+       * the change event to fire for this media query.
+       */
+      const media = matchMedia("(display-mode: standalone)");
+
+      const resizeWindow = (ev) => {
+        if (ev === undefined || ev.matches) {
           window.resizeTo(500, 375);
+          media.removeEventListener('change', resizeWindow);
         }
-      });
+      }
+      if (media.matches) {
+        resizeWindow();
+      } else {
+        media.addEventListener('change', resizeWindow);
+      }
     </script>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,14 @@
   </head>
   <body>
     <div id="app"></div>
+    <script>
+      document.addEventListener("DOMContentLoaded", event => {
+        isBrowser = matchMedia("(display-mode: browser)").matches;
+        if (!isBrowser) {
+          window.resizeTo(500, 375);
+        }
+      });
+    </script>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,4 @@ import { checkmark, eyedrop, clipboard, colorPalette } from 'ionicons/icons';
 defineCustomElement();
 addIcons({ checkmark, eyedrop, clipboard, colorPalette });
 
-
-window.resizeTo(500, 375);
-
 createApp(App).mount('#app')

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       injectRegister: 'auto',
       registerType: 'autoUpdate',
       manifest: {
+        display: 'standalone',
         background_color: '#000000',
         theme_color: '#000000',
         icons: [


### PR DESCRIPTION
We use `resizeTo` to make the PWA window smaller. However, this only appears to work when `display-mode` does NOT match `browser`. I initially thought `display-mode` would match `standalone` on first load, but apparently that is not the case. I also tried waiting for DOMContentLoaded as per https://web.dev/learn/pwa/windows/, but that did not work either -- the media query still matched `browser`. In the end, I decided to listen for a change to the media query if necessary and then do the resize.