### PR TITLE
chore: update playwright and docker image together

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,4 +4,32 @@
   dependencyDashboard: false,
   minimumReleaseAge: '3 days',
   semanticCommits: 'enabled',
+  packageRules: [
+    {
+      $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+      extends: ['config:base', ':semanticCommitTypeAll(chore)'],
+      dependencyDashboard: false,
+      minimumReleaseAge: '3 days',
+      semanticCommits: 'enabled',
+      packageRules: [
+        {
+          matchDatasources: ["npm"],
+          matchPackagePatterns: ["@playwright/test", "@axe-core/playwright"],
+          groupName: "playwright",
+          matchFileNames: [
+            "package.json"
+          ]
+        },
+        {
+          matchDatasources: ["docker"],
+          matchPackageNames: ["mcr.microsoft.com/playwright"],
+          groupName: "playwright",
+          matchFileNames: [
+            "Dockerfile"
+          ],
+          versioning: "semver"
+        },
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
The Playwright deps for npm and Docker need to be updated at the same time otherwise tests will fail.