### PR TITLE
chore: use correct renovatebot key

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,7 +14,7 @@
       packageRules: [
         {
           matchDatasources: ["npm"],
-          matchPackagePatterns: ["@playwright/test", "@axe-core/playwright"],
+          matchPackageNames: ["@playwright/test", "@axe-core/playwright"],
           groupName: "playwright",
           matchFileNames: [
             "package.json"


### PR DESCRIPTION
We don't need to do pattern matching here because we're listing explicit package names.