### PR TITLE
chore: docker deps clean up

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
         run: pnpm run build
         shell: sh
       - name: Run Tests
-        run: pnpm run test.docker
+        run: pnpm run test.docker.ci
         shell: sh
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,8 +13,6 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/playwright:v1.39.0-jammy
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -30,8 +28,7 @@ jobs:
         run: pnpm run build
         shell: sh
       - name: Run Tests
-        # https://github.com/microsoft/playwright/issues/6500
-        run: HOME=/root pnpm run test
+        run: pnpm run test.docker
         shell: sh
       - uses: actions/upload-artifact@v3
         if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # Get Playwright
 FROM mcr.microsoft.com/playwright:v1.39.0
 
+# Enable corepack which lets us use pnpm
+RUN corepack enable
+
 # Set the working directory
 WORKDIR /contrast

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview",
     "test": "playwright test",
     "generate-assets": "pwa-assets-generator",
-    "test.docker": "docker build -t contrast-playwright . && docker run -it --rm --ipc=host --mount=type=bind,source=./,target=/contrast contrast-playwright pnpm run test --",
-    "test.docker.ci": "docker build -t contrast-playwright . && docker run --rm --ipc=host --mount=type=bind,source=./,target=/contrast contrast-playwright pnpm run test --"
+    "test.docker": "docker build -t contrast-playwright . && docker run -it --rm --ipc=host --mount=type=bind,source=./,target=/contrast contrast-playwright pnpm run test",
+    "test.docker.ci": "docker build -t contrast-playwright . && docker run --rm --ipc=host --mount=type=bind,source=./,target=/contrast contrast-playwright pnpm run test"
   },
   "dependencies": {
     "color-contrast-calc": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "test": "playwright test",
     "generate-assets": "pwa-assets-generator",
-    "test.docker": "docker build -t contrast-playwright . && docker run -it --rm --ipc=host --mount=type=bind,source=./,target=/contrast contrast-playwright pnpm run test --"
+    "test.docker": "docker build -t contrast-playwright . && docker run -it --rm --ipc=host --mount=type=bind,source=./,target=/contrast contrast-playwright pnpm run test --",
+    "test.docker.ci": "docker build -t contrast-playwright . && docker run --rm --ipc=host --mount=type=bind,source=./,target=/contrast contrast-playwright pnpm run test --"
   },
   "dependencies": {
     "color-contrast-calc": "^0.4.1",


### PR DESCRIPTION
For consistency, running tests on CI will use the same Dockerfile that is used during local development.