### PR TITLE
chore: ensure renovatebot prs cause CI to run

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,9 +1,8 @@
 name: Build app and run tests
 
 on:
-  push:
-    branches:
-      - '*'
+  pull_request:
+    branches: [ '**' ]
 
 concurrency:
   # Cancel in progress runs for this branch


### PR DESCRIPTION
Renovatebot PRs do not have their CI checks run. As a result, we cannot see if dep updates break the build.