### PR TITLE
chore: ensure pages and artifact actions are updated at the same time

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -16,7 +16,7 @@
           /**
            * The GitHub Pages actions tend to depend on one another, so update them at the same time.
            */
-          matchPackageName: ['actions/upload-artifact', 'actions/upload-pages-artifact', 'actions/deploy-pages'],
+          matchPackageNames: ['actions/upload-artifact', 'actions/upload-pages-artifact', 'actions/deploy-pages'],
           groupName: 'artifact-and-pages',
         },
         {

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,13 @@
       semanticCommits: 'enabled',
       packageRules: [
         {
+          /**
+           * The GitHub Pages actions tend to depend on one another, so update them at the same time.
+           */
+          matchPackageName: ['actions/upload-artifact', 'actions/upload-pages-artifact', 'actions/deploy-pages'],
+          groupName: 'artifact-and-pages',
+        },
+        {
           matchDatasources: ["npm"],
           matchPackageNames: ["@playwright/test", "@axe-core/playwright"],
           groupName: "playwright",

--- a/renovate.json5
+++ b/renovate.json5
@@ -20,21 +20,21 @@
           groupName: 'artifact-and-pages',
         },
         {
-          matchDatasources: ["npm"],
-          matchPackageNames: ["@playwright/test", "@axe-core/playwright"],
-          groupName: "playwright",
+          matchDatasources: ['npm'],
+          matchPackageNames: ['@playwright/test', '@axe-core/playwright'],
+          groupName: 'playwright',
           matchFileNames: [
-            "package.json"
+            'package.json'
           ]
         },
         {
-          matchDatasources: ["docker"],
-          matchPackageNames: ["mcr.microsoft.com/playwright"],
-          groupName: "playwright",
+          matchDatasources: ['docker'],
+          matchPackageNames: ['mcr.microsoft.com/playwright'],
+          groupName: 'playwright',
           matchFileNames: [
-            "Dockerfile"
+            'Dockerfile'
           ],
-          versioning: "semver"
+          versioning: 'semver'
         },
       ]
     }


### PR DESCRIPTION
I noticed that `actions/deploy-pages` has [compatibility with specific versions](https://github.com/actions/deploy-pages/releases/tag/v4.0.0) of `actions/upload-artifact` and `actions/upload-pages-artifact`, so these should be updated at the same time. 