### PR TITLE
chore: remove pnpm dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@vite-pwa/assets-generator": "^0.0.10",
     "@vitejs/plugin-vue": "^4.2.3",
     "generator": "link:@vite-pwa@assets/generator",
-    "pnpm": "^8.15.1",
     "serve": "^14.2.1",
     "typescript": "^5.0.2",
     "vite": "^4.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,9 +34,6 @@ devDependencies:
   generator:
     specifier: link:@vite-pwa@assets/generator
     version: link:@vite-pwa@assets/generator
-  pnpm:
-    specifier: ^8.15.1
-    version: 8.15.1
   serve:
     specifier: ^14.2.1
     version: 14.2.1
@@ -3198,12 +3195,6 @@ packages:
       playwright-core: 1.39.0
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
-
-  /pnpm@8.15.1:
-    resolution: {integrity: sha512-gxz0xfi4N0r3FSHU0VPbSdcIbeYVwq98tenX64umMN2sRv6kldZD5VLvLmijqpmj5en77oaWcClnUE31xZyycw==}
-    engines: {node: '>=16.14'}
-    hasBin: true
     dev: true
 
   /postcss@8.4.31:


### PR DESCRIPTION
pnpm should be a global dependency not a dependency specific to this project. This PR removes the dependency from `package.json`.