### PR TITLE
fix: account for when no good color can be found

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
 import { ref, watch } from 'vue';
 import { ColorContrastCalc } from 'color-contrast-calc';
 
-import { computeContrast } from './utils';
+import { computeContrast, computeFallbackColors } from './utils';
 
 import DropperButton from './components/DropperButton.vue';
 import CopyButton from './components/CopyButton.vue';
@@ -86,18 +86,7 @@ watch([foreground, background], () => {
      * Compare white text and black text contrast on chosen
      * background and use whichever one has the higher ratio.
      */
-    const whiteForegroundRGB = ColorContrastCalc.colorFrom('#ffffff');
-    const blackForegroundRGB = ColorContrastCalc.colorFrom('#000000');
-    const backgroundRGB = ColorContrastCalc.colorFrom(background.value);
-    
-    const whiteRatio = whiteForegroundRGB.contrastRatioAgainst(backgroundRGB);
-    const blackRatio = blackForegroundRGB.contrastRatioAgainst(backgroundRGB);
-    
-    if (whiteRatio >= blackRatio) {
-      foregroundTextColor.value = backgroundTextColor.value = '#ffffff';
-    } else {
-      foregroundTextColor.value = backgroundTextColor.value = '#000000';
-    }
+    foregroundTextColor.value = backgroundTextColor.value = computeFallbackColors(background.value);
   } else {
     foregroundTextColor.value = background.value;
     backgroundTextColor.value = foreground.value;

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue';
-import { ColorContrastCalc } from 'color-contrast-calc';
 
 import { computeContrast, computeFallbackColors } from './utils';
 

--- a/src/components/AdjustButton.vue
+++ b/src/components/AdjustButton.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">  
   import { colorWand, checkmark } from 'ionicons/icons';
-  import { computeContrast } from '../utils';
+  import { computeContrast, computeFallbackColors } from '../utils';
   import { ColorContrastCalc } from 'color-contrast-calc';
   import { ref } from 'vue';
 
@@ -16,7 +16,18 @@
       const foregroundColor = ColorContrastCalc.colorFrom(props.foreground);
       const backgroundColor = ColorContrastCalc.colorFrom(props.modelValue);
       
-      const adjustedBackgroundColor = foregroundColor.findBrightnessThreshold(backgroundColor, 'AA');
+      let adjustedBackgroundColor = foregroundColor.findBrightnessThreshold(backgroundColor, 'AA');
+      
+      /**
+       * Sometimes findBrightnessThreshold can't find a color with sufficient contrast.
+       * When that happens use either #000 or #fff, whichever has the higher contrast.
+       */
+      const computeContrastAgain = computeContrast(props.foreground, adjustedBackgroundColor.hexCode);
+      if (computeContrastAgain < 4.5) {
+        const fallbackColor = computeFallbackColors(props.modelValue);
+        adjustedBackgroundColor = ColorContrastCalc.colorFrom(fallbackColor);
+      }
+
       emit('update:modelValue', adjustedBackgroundColor.hexCode);
     }
     

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,3 +12,22 @@ export const computeContrast = (foreground: string, background: string) => {
    */
   return ratio.toString().match(/^-?\d+(?:\.\d{0,2})?/)[0];
 }
+
+export const computeFallbackColors = (background: string) => {
+  /**
+   * Compare white text and black text contrast on chosen
+   * background and use whichever one has the higher ratio.
+   */
+  const whiteForegroundRGB = ColorContrastCalc.colorFrom('#ffffff');
+  const blackForegroundRGB = ColorContrastCalc.colorFrom('#000000');
+  const backgroundRGB = ColorContrastCalc.colorFrom(background);
+  
+  const whiteRatio = whiteForegroundRGB.contrastRatioAgainst(backgroundRGB);
+  const blackRatio = blackForegroundRGB.contrastRatioAgainst(backgroundRGB);
+  
+  if (whiteRatio >= blackRatio) {
+    return '#ffffff';
+  } else {
+    return '#000000';
+  }
+}


### PR DESCRIPTION
Sometimes the color adjustment tool can't find a good color within the chosen color palette such that the contrast meets a ratio of 4.5:1. In those cases we fallback to using either white or black, whichever one yields the higher contrast.

Example:

Background: `#ffffff`
Foreground: `#fffbb9`

Technically `#707070` is sufficient here as a background, but the color adjust util does not seem to choose that. There may be opportunity for improvement here by modifying how the tool chooses colors. However, this fallback at least ensures adjusted colors meet the 4.5:1 contrast ratio.

Interestingly, using `#ebebeb` (slightly darker than white) as the background does not reproduce the issue.