### PR TITLE
chore(renovate): automerge minor and patch dep updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,6 +6,11 @@
   semanticCommits: 'enabled',
   packageRules: [
     {
+      matchUpdateTypes: ['minor', 'patch'],
+      matchCurrentVersion: '!/^0/',
+      automerge: true
+    },
+    {
       matchPackageNames: ['vue', 'vue-tsc'],
       groupName: 'vue'
     },


### PR DESCRIPTION
This should help ensure dependencies are updated more frequently & so I don't have to manually review low-risk dependency bumps